### PR TITLE
add preserve_perms to doinst.sh

### DIFF
--- a/slackbuild/doinst.sh
+++ b/slackbuild/doinst.sh
@@ -8,6 +8,18 @@ config() {
   fi
 }
 
+preserve_perms() {
+  NEW="$1"
+  OLD="$(dirname $NEW)/$(basename $NEW .new)"
+  if [ -e $OLD ]; then
+    cp -a $OLD ${NEW}.incoming
+    cat $NEW > ${NEW}.incoming
+    mv ${NEW}.incoming $NEW
+  fi
+  config $NEW
+}
+
+preserve_perms etc/rc.d/rc.sun.new
 config etc/sun/sun.conf.new
 
 if [ -x /usr/bin/update-desktop-database ]; then


### PR DESCRIPTION
Hi,

I suggest to keep the permission on the file /etc/rc.d/rc.sun when we have to upgrade the package.

By the way, this applet is very cool !

Regards,
Thibaut